### PR TITLE
lock in all container version and correct keycloak pod spec

### DIFF
--- a/api/v1alpha1/horreum_types.go
+++ b/api/v1alpha1/horreum_types.go
@@ -55,7 +55,7 @@ type ExternalSpec struct {
 type KeycloakSpec struct {
 	// When this is set Keycloak instance will not be deployed and Horreum will use this external instance.
 	External ExternalSpec `json:"external,omitempty"`
-	// Image that should be used for Keycloak deployment. Defaults to quay.io/keycloak/keycloak:latest
+	// Image that should be used for Keycloak deployment. Defaults to quay.io/keycloak/keycloak:22.0
 	Image string `json:"image,omitempty"`
 	// Route for external access to the Keycloak instance.
 	Route RouteSpec `json:"route,omitempty"`
@@ -72,7 +72,7 @@ type KeycloakSpec struct {
 type PostgresSpec struct {
 	// True (or omitted) to deploy PostgreSQL database
 	Enabled *bool `json:"enabled,omitempty"`
-	// Image used for PostgreSQL deployment. Defaults to registry.redhat.io/rhel8/postgresql-12:latest
+	// Image used for PostgreSQL deployment. Defaults to registry.redhat.io/rhel8/postgresql-12:1-144
 	Image string `json:"image,omitempty"`
 	// Secret used for unrestricted access to the database. Created if does not exist.
 	// Must contain keys `username` and `password`.
@@ -93,7 +93,7 @@ type HorreumSpec struct {
 	Route RouteSpec `json:"route,omitempty"`
 	// Alternative service type when routes are not available (e.g. on vanilla K8s)
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
-	// Horreum image. Defaults to quay.io/hyperfoil/horreum:latest
+	// Horreum image. Defaults to quay.io/hyperfoil/horreum:0.7.11
 	Image string `json:"image,omitempty"`
 	// Database coordinates for Horreum data. Besides `username` and `password` the secret must
 	// also contain key `dbsecret` that will be used to sign access to the database.

--- a/config/crd/bases/hyperfoil.io_horreums.yaml
+++ b/config/crd/bases/hyperfoil.io_horreums.yaml
@@ -82,7 +82,7 @@ spec:
                     type: string
                 type: object
               image:
-                description: Horreum image. Defaults to quay.io/hyperfoil/horreum:latest
+                description: Horreum image. Defaults to quay.io/hyperfoil/horreum:0.7.11
                 type: string
               keycloak:
                 description: Keycloak specification
@@ -125,7 +125,7 @@ spec:
                     type: object
                   image:
                     description: Image that should be used for Keycloak deployment.
-                      Defaults to quay.io/keycloak/keycloak:latest
+                      Defaults to quay.io/keycloak/keycloak:22.0
                     type: string
                   route:
                     description: Route for external access to the Keycloak instance.
@@ -165,7 +165,7 @@ spec:
                     type: boolean
                   image:
                     description: Image used for PostgreSQL deployment. Defaults to
-                      registry.redhat.io/rhel8/postgresql-12:latest
+                      registry.redhat.io/rhel8/postgresql-12:1-144
                     type: string
                   persistentVolumeClaim:
                     description: Name of PVC where the database will store the data.

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -35,11 +35,11 @@ func horreumAdminSecret(cr *hyperfoilv1alpha1.Horreum) string {
 
 func dbImage(cr *hyperfoilv1alpha1.Horreum, useRedHatImage bool) string {
 	return withDefault(cr.Spec.Postgres.Image,
-		ifThenElse(useRedHatImage, "registry.redhat.io/rhel8/postgresql-12:latest", "docker.io/library/postgres:14.4"))
+		ifThenElse(useRedHatImage, "registry.redhat.io/rhel8/postgresql-12:1-144", "docker.io/library/postgres:14.4"))
 }
 
 func appImage(cr *hyperfoilv1alpha1.Horreum) string {
-	return withDefault(cr.Spec.Image, "quay.io/hyperfoil/horreum:latest")
+	return withDefault(cr.Spec.Image, "quay.io/hyperfoil/horreum:0.7.11")
 }
 
 func keycloakInternalURL(cr *hyperfoilv1alpha1.Horreum) string {

--- a/controllers/keycloak.go
+++ b/controllers/keycloak.go
@@ -51,7 +51,8 @@ func keycloakPod(cr *hyperfoilv1alpha1.Horreum, keycloakPublicUrl string) *corev
 			Containers: []corev1.Container{
 				{
 					Name:  "keycloak",
-					Image: withDefault(cr.Spec.Keycloak.Image, "quay.io/hyperfoil/horreum-keycloak:latest"),
+					Image: withDefault(cr.Spec.Keycloak.Image, "quay.io/keycloak/keycloak:22.0"),
+					Args: []string{"start"},
 					Env: []corev1.EnvVar{
 						secretEnv("KEYCLOAK_ADMIN", keycloakAdminSecret(cr), corev1.BasicAuthUsernameKey),
 						secretEnv("KEYCLOAK_ADMIN_PASSWORD", keycloakAdminSecret(cr), corev1.BasicAuthPasswordKey),

--- a/controllers/keycloak.go
+++ b/controllers/keycloak.go
@@ -95,10 +95,6 @@ func keycloakPod(cr *hyperfoilv1alpha1.Horreum, keycloakPublicUrl string) *corev
 						},
 						secretEnv("KC_DB_USERNAME", keycloakDbSecret(cr), corev1.BasicAuthUsernameKey),
 						secretEnv("KC_DB_PASSWORD", keycloakDbSecret(cr), corev1.BasicAuthPasswordKey),
-						{
-							Name:  "KEYCLOAK_COMMAND",
-							Value: "start",
-						},
 					},
 					Ports: []corev1.ContainerPort{
 						{


### PR DESCRIPTION
This PR corrects two issues with the existing operator configs.

- All dependency pod versions are now locked into explicit release tags instead of using the `:latest` tags.
- The pod spec for the keycloak pod has been updated to pass the `start` argument to the pod, which corrects problems starting keycloak pods from the upstream repository.

Fixes #18 